### PR TITLE
Fix cloned children of custom element shadowRoot not being cloned into new shadowRoot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.0",
+      "name": "html2canvas",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "html2canvas",
-      "version": "1.4.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -175,7 +175,8 @@ export class DocumentCloner {
     createCustomElementClone(node: HTMLElement): HTMLElement {
         const clone = document.createElement('html2canvas-custom-element');
         copyCSSStyles(node.style, clone);
-        clone.attachShadow({mode: 'open'});
+
+        if (typeof clone.attachShadow !== 'undefined') clone.attachShadow({mode: 'open'});
 
         return clone;
     }

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -283,6 +283,9 @@ export class DocumentCloner {
                 (typeof this.options.ignoreElements !== 'function' || !this.options.ignoreElements(child)))
         ) {
             if (!this.options.copyStyles || !isElementNode(child) || !isStyleElement(child)) {
+                /* If an element was inside a custom element shadowRoot, clone it
+                 * into a shadowRoot, primarily to prevent leaking of styles into
+                 * the top-level DOM */
                 if (isInShadow && clone.shadowRoot) {
                     clone.shadowRoot.appendChild(this.cloneNode(child, copyStyles));
                     return;

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -173,9 +173,8 @@ export class DocumentCloner {
     }
 
     createCustomElementClone(node: HTMLElement): HTMLElement {
-        const clone = document.createElement('html2canvas-custom-element');
+        const clone = document.createElement('html2canvascustomelement');
         copyCSSStyles(node.style, clone);
-        clone.attachShadow({mode: 'open'});
 
         return clone;
     }
@@ -274,7 +273,7 @@ export class DocumentCloner {
         return blankCanvas;
     }
 
-    appendChildNode(clone: HTMLElement | SVGElement, child: Node, copyStyles: boolean, isInShadow: boolean): void {
+    appendChildNode(clone: HTMLElement | SVGElement, child: Node, copyStyles: boolean): void {
         if (
             !isElementNode(child) ||
             (!isScriptElement(child) &&
@@ -282,11 +281,6 @@ export class DocumentCloner {
                 (typeof this.options.ignoreElements !== 'function' || !this.options.ignoreElements(child)))
         ) {
             if (!this.options.copyStyles || !isElementNode(child) || !isStyleElement(child)) {
-
-                if (isInShadow && clone.shadowRoot) {
-                    clone.shadowRoot.appendChild(this.cloneNode(child, copyStyles));
-                    return;
-                }
                 clone.appendChild(this.cloneNode(child, copyStyles));
             }
         }
@@ -298,17 +292,13 @@ export class DocumentCloner {
             child;
             child = child.nextSibling
         ) {
-            if (node.shadowRoot) {
-                this.appendChildNode(clone, child, copyStyles, true);
-                continue;
-            }
             if (isElementNode(child) && isSlotElement(child) && typeof child.assignedNodes === 'function') {
                 const assignedNodes = child.assignedNodes() as ChildNode[];
                 if (assignedNodes.length) {
-                    assignedNodes.forEach((assignedNode) => this.appendChildNode(clone, assignedNode, copyStyles, false));
+                    assignedNodes.forEach((assignedNode) => this.appendChildNode(clone, assignedNode, copyStyles));
                 }
             } else {
-                this.appendChildNode(clone, child, copyStyles, false);
+                this.appendChildNode(clone, child, copyStyles);
             }
         }
     }

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -173,8 +173,9 @@ export class DocumentCloner {
     }
 
     createCustomElementClone(node: HTMLElement): HTMLElement {
-        const clone = document.createElement('html2canvascustomelement');
+        const clone = document.createElement('html2canvas-custom-element');
         copyCSSStyles(node.style, clone);
+        clone.attachShadow({mode: 'open'});
 
         return clone;
     }
@@ -273,7 +274,7 @@ export class DocumentCloner {
         return blankCanvas;
     }
 
-    appendChildNode(clone: HTMLElement | SVGElement, child: Node, copyStyles: boolean): void {
+    appendChildNode(clone: HTMLElement | SVGElement, child: Node, copyStyles: boolean, isInShadow: boolean): void {
         if (
             !isElementNode(child) ||
             (!isScriptElement(child) &&
@@ -281,6 +282,11 @@ export class DocumentCloner {
                 (typeof this.options.ignoreElements !== 'function' || !this.options.ignoreElements(child)))
         ) {
             if (!this.options.copyStyles || !isElementNode(child) || !isStyleElement(child)) {
+
+                if (isInShadow && clone.shadowRoot) {
+                    clone.shadowRoot.appendChild(this.cloneNode(child, copyStyles));
+                    return;
+                }
                 clone.appendChild(this.cloneNode(child, copyStyles));
             }
         }
@@ -292,13 +298,17 @@ export class DocumentCloner {
             child;
             child = child.nextSibling
         ) {
+            if (node.shadowRoot) {
+                this.appendChildNode(clone, child, copyStyles, true);
+                continue;
+            }
             if (isElementNode(child) && isSlotElement(child) && typeof child.assignedNodes === 'function') {
                 const assignedNodes = child.assignedNodes() as ChildNode[];
                 if (assignedNodes.length) {
-                    assignedNodes.forEach((assignedNode) => this.appendChildNode(clone, assignedNode, copyStyles));
+                    assignedNodes.forEach((assignedNode) => this.appendChildNode(clone, assignedNode, copyStyles, false));
                 }
             } else {
-                this.appendChildNode(clone, child, copyStyles);
+                this.appendChildNode(clone, child, copyStyles, false);
             }
         }
     }

--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -282,7 +282,6 @@ export class DocumentCloner {
                 (typeof this.options.ignoreElements !== 'function' || !this.options.ignoreElements(child)))
         ) {
             if (!this.options.copyStyles || !isElementNode(child) || !isStyleElement(child)) {
-
                 if (isInShadow && clone.shadowRoot) {
                     clone.shadowRoot.appendChild(this.cloneNode(child, copyStyles));
                     return;
@@ -305,7 +304,9 @@ export class DocumentCloner {
             if (isElementNode(child) && isSlotElement(child) && typeof child.assignedNodes === 'function') {
                 const assignedNodes = child.assignedNodes() as ChildNode[];
                 if (assignedNodes.length) {
-                    assignedNodes.forEach((assignedNode) => this.appendChildNode(clone, assignedNode, copyStyles, false));
+                    assignedNodes.forEach((assignedNode) =>
+                        this.appendChildNode(clone, assignedNode, copyStyles, false)
+                    );
                 }
             } else {
                 this.appendChildNode(clone, child, copyStyles, false);

--- a/tests/reftests/webcomponents/autonomous-custom-element.js
+++ b/tests/reftests/webcomponents/autonomous-custom-element.js
@@ -18,13 +18,6 @@ class AutonomousCustomElement extends HTMLElement {
         const style = document.createElement('style');
 
         style.textContent = `
-
-      /* Non-namespaced style that will leak into the page DOM if the style
-         is cloned outside of a shadow root*/
-      body {
-        background: red;
-      }
-
       .wrapper {
         position: relative;
       }

--- a/tests/reftests/webcomponents/autonomous-custom-element.js
+++ b/tests/reftests/webcomponents/autonomous-custom-element.js
@@ -18,6 +18,13 @@ class AutonomousCustomElement extends HTMLElement {
         const style = document.createElement('style');
 
         style.textContent = `
+
+      /* Non-namespaced style that will leak into the page DOM if the style
+         is cloned outside of a shadow root*/
+      body {
+        background: red;
+      }
+
       .wrapper {
         position: relative;
       }


### PR DESCRIPTION
When cloning a custom element that uses a shadowRoot, the new children should be appended to a shadowRoot of the cloned parent. Primarily, this avoids poorly-namespaced stylesheets from polluting the main DOM.